### PR TITLE
Python 3 compatibility

### DIFF
--- a/rcs_latexdiff/rcs.py
+++ b/rcs_latexdiff/rcs.py
@@ -1,7 +1,9 @@
+from __future__ import print_function, absolute_import
+
 import os
 import logging
 
-from utils import run_command
+from .utils import run_command
 
 logger = logging.getLogger("rcs-latexdiff")
 

--- a/rcs_latexdiff/rcs_latexdiff.py
+++ b/rcs_latexdiff/rcs_latexdiff.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import
+
 import re
 import argparse
 import logging
@@ -7,8 +9,8 @@ import sys
 import subprocess
 import distutils.spawn
 
-from rcs import get_rcs_class
-from utils import run_command, write_file, remove_latex_comments
+from .rcs import get_rcs_class
+from .utils import run_command, write_file, remove_latex_comments
 
 
 logger = logging.getLogger("rcs-latexdiff")
@@ -346,7 +348,7 @@ def check_latexdiff():
 
     # latexdiff tool not available ?
     if ret:
-        print """latexdiff tool not found in PATH
+        print("""latexdiff tool not found in PATH
 Install it or correct your PATH
 
 You can install it as follows:
@@ -354,7 +356,7 @@ You can install it as follows:
         apt-get install latexdiff
     MacPorts (OS X):
         sudo port install latexdiff
-"""
+""")
         exit(1)
 
 

--- a/rcs_latexdiff/utils.py
+++ b/rcs_latexdiff/utils.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import
+
 import subprocess
 import logging
 import re
@@ -17,17 +19,17 @@ def run_command(command, path=""):
     try:
         # Forge command
         if path not in ['', '.']:
-            command = '(cd %s && %s)' % (path, command)
+            command = '(cd {} && {})'.format(path, command)
 
         logger.debug("Run command: %s" % (command))
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        output = process.communicate()[0]
+        output = process.communicate()[0].decode('utf-8')
         retcode = process.returncode
 
         logger.debug("Return code: %d" % (retcode))
         return retcode, output
 
-    except OSError, e:
+    except OSError as e:
         logger.info("Execution failed: %s" % (e))
         exit(1)
 


### PR DESCRIPTION
This PR fixes a few things like ``print`` and ``str``/``bytes`` to allow ``rcs-latexdiff`` to run on Python 3.